### PR TITLE
bau: Nicer travis, fix bintray publish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: java
+env:
+  - VERIFY_USE_PUBLIC_BINARIES=true
 jdk:
   - oraclejdk8
   - oraclejdk9
@@ -6,6 +8,11 @@ jdk:
 matrix:
   allow_failures:
   - jdk: oraclejdk9
-before_install:
-# this is a hack, so PR builds can be tested in travis
-  - perl -i -0pe 's/maven[\s\{]+[^\{\}]*\}/maven { url \"https:\/\/build.shibboleth.net\/nexus\/content\/groups\/public\" \n url \"https:\/\/repo1.maven.org\/maven2\" \n jcenter() }/gms' build.gradle
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
+

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-plugins { id "com.jfrog.bintray" version "1.7.3" }
+plugins { id "com.jfrog.bintray" version "1.8.0" }
 apply plugin: 'java'
 apply plugin: 'maven-publish'
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,14 @@
-plugins {
-    id "com.jfrog.bintray" version "1.7.3"
-}
-
+plugins { id "com.jfrog.bintray" version "1.7.3" }
 apply plugin: 'java'
 apply plugin: 'maven-publish'
 
 repositories {
-    mavenCentral()
+    if (System.getenv('VERIFY_USE_PUBLIC_BINARIES') == 'true') {
+        mavenCentral()
+    }
+    else {
+        maven { url 'https://artifactory.ida.digital.cabinet-office.gov.uk/artifactory/whitelisted-repos' }
+    }
 }
 
 def dependencyVersions = [
@@ -51,7 +53,7 @@ bintray {
     publications = ['mavenJava']
     publish = true
     pkg {
-        repo = 'maven'
+        repo = 'maven-test'
         name = 'dropwizard-infinispan'
         userOrg = 'alphagov'
         licenses = ['MIT']


### PR DESCRIPTION
It looks like this library was half done in terms of pushing to bintray
- the bintray plugin was there, but it isn't in bintray, so it's fair to
assume it wasn't working.

Update it to match the other libraries and replace the perl hack with an
environment variable based feature flag.