### PR TITLE
Trello-szcv9iCz: Upgrade to Dropwizard 1.3.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /.gradle/
 /build/
 .idea/
+out/

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ repositories {
 }
 
 def dependencyVersions = [
-        dropwizard:"1.1.4"
+        dropwizard:"1.3.5"
 ]
 
 dependencies {

--- a/src/main/java/uk/gov/ida/shared/dropwizard/infinispan/util/InfinispanCacheManager.java
+++ b/src/main/java/uk/gov/ida/shared/dropwizard/infinispan/util/InfinispanCacheManager.java
@@ -1,7 +1,7 @@
 package uk.gov.ida.shared.dropwizard.infinispan.util;
 
-import com.codahale.metrics.JmxAttributeGauge;
 import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.jvm.JmxAttributeGauge;
 import com.google.common.base.Throwables;
 import io.dropwizard.lifecycle.Managed;
 import org.infinispan.Cache;


### PR DESCRIPTION
- We need to upgrade dropwizard to 1.3.5 in hub so
its dependent libs need it too