### PR TITLE
BAU Upgrade dropwizard to 1.3.9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ repositories {
 }
 
 def dependencyVersions = [
-        dropwizard:"1.3.5"
+        dropwizard:"1.3.9"
 ]
 
 dependencies {


### PR DESCRIPTION
1.3.5 was susceptible to a range of CVEs. To upgrade the hub we should
also upgrade here.