### PR TITLE
BAU: Upgrade dropwizard to 1.3.18

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ repositories {
 }
 
 def dependencyVersions = [
-        dropwizard: "1.3.17"
+        dropwizard: "1.3.18"
 ]
 
 dependencies {


### PR DESCRIPTION
It mitigates CVE-2019-20220.

https://github.com/dropwizard/dropwizard/releases/tag/v1.3.18